### PR TITLE
adapters with different length or length more then 32 https://github.…

### DIFF
--- a/src/FalcoConfig.cpp
+++ b/src/FalcoConfig.cpp
@@ -514,6 +514,8 @@ FalcoConfig::read_adapters() {
   adapter_names.clear();
   adapter_seqs.clear();
   adapter_hashes.clear();
+  do_adapter_optimized = true;
+  
   while (getline(in, line)) {
     if (is_content_line(line)) {
       if (adapter_names.size() > Constants::max_adapters)
@@ -532,8 +534,8 @@ FalcoConfig::read_adapters() {
         adapter_seq = line_by_space.back();
 
         if (adapter_seq.size() > 32) {
-          cerr << "adapter size is more then 32. Use slow adapters search" << "\n";
-          adapters_search_slow = true;
+          cerr << "[adapters]\tadapter size is more then 32. Use slow adapters search" << "\n";
+          do_adapter_optimized = false;
         }
       }
 
@@ -547,8 +549,8 @@ FalcoConfig::read_adapters() {
         longest_adapter_size = adapter_size;
       }
       else if (adapter_seq.size() != adapter_size) {
-        cerr << "adapters has different size. Use slow adapters search" << "\n";
-        adapters_search_slow = true;
+        cerr << "[adapters]\tadapters have different size. Use slow adapters search" << "\n";
+        do_adapter_optimized = false;
         if(adapter_seq.size() > longest_adapter_size){
           longest_adapter_size = adapter_seq.size();
         }

--- a/src/FalcoConfig.cpp
+++ b/src/FalcoConfig.cpp
@@ -531,10 +531,10 @@ FalcoConfig::read_adapters() {
           adapter_name += line_by_space[i] + " ";
         adapter_seq = line_by_space.back();
 
-        if (adapter_seq.size() > 32)
-          throw runtime_error("adapter too long. Maximum adapter size is 32bp: "
-                              + adapter_seq);
-
+        if (adapter_seq.size() > 32) {
+          cerr << "adapter size is more then 32. Use slow adapters search" << "\n";
+          adapters_search_slow = true;
+        }
       }
 
       // store information
@@ -542,10 +542,17 @@ FalcoConfig::read_adapters() {
       adapter_seqs.push_back(adapter_seq);
       adapter_hashes.push_back(hash_adapter(adapter_seq));
 
-      if (adapter_size == 0)
+      if (adapter_size == 0) {
         adapter_size = adapter_seq.size();
-      else if (adapter_seq.size() != adapter_size)
-        throw runtime_error("adapters in config are not all of same size");
+        longest_adapter_size = adapter_size;
+      }
+      else if (adapter_seq.size() != adapter_size) {
+        cerr << "adapters has different size. Use slow adapters search" << "\n";
+        adapters_search_slow = true;
+        if(adapter_seq.size() > longest_adapter_size){
+          longest_adapter_size = adapter_seq.size();
+        }
+      }
 
       line_by_space.clear();
     }

--- a/src/FalcoConfig.hpp
+++ b/src/FalcoConfig.hpp
@@ -63,6 +63,7 @@ struct FalcoConfig {
        do_quality_sequence,
        do_tile,
        do_adapter,
+       do_adapter_optimized,
        do_sequence_length;
 
   /************************************************************
@@ -89,7 +90,6 @@ struct FalcoConfig {
 
   size_t adapter_size;
   size_t longest_adapter_size;
-  bool adapters_search_slow;
   /************************************************************
    ******* ADDITIONAL INFORMATION ABOUT THE SAMPLE ************
    ************************************************************/

--- a/src/FalcoConfig.hpp
+++ b/src/FalcoConfig.hpp
@@ -88,6 +88,8 @@ struct FalcoConfig {
   std::vector<size_t> adapter_hashes;
 
   size_t adapter_size;
+  size_t longest_adapter_size;
+  bool adapters_search_slow;
   /************************************************************
    ******* ADDITIONAL INFORMATION ABOUT THE SAMPLE ************
    ************************************************************/

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -1820,7 +1820,8 @@ Module(ModuleAdapterContent::module_name) {
   adapter_names = config.adapter_names;
   adapter_seqs = config.adapter_seqs;
   adapter_hashes = config.adapter_hashes;
-
+  longest_adapter_size = config.longest_adapter_size; 
+  
   // check if they are all the same size
   if (adapter_names.size() != adapter_seqs.size())
     throw runtime_error("Adapter name and sequence vector sizes differ");
@@ -1847,7 +1848,7 @@ ModuleAdapterContent::summarize_module(FastqStats &stats) {
 
   for (size_t i = 0; i < num_adapters; ++i)
     adapter_pos_pct.push_back(
-        vector<double>(num_bases - adapter_size + 1, 0.0)
+        vector<double>(num_bases - longest_adapter_size + 1, 0.0)
     );
 
   size_t cnt;

--- a/src/Module.hpp
+++ b/src/Module.hpp
@@ -340,6 +340,7 @@ class ModuleAdapterContent : public Module {
    std::vector<std::string> adapter_names;
    std::vector<std::string> adapter_seqs;
    std::vector<size_t> adapter_hashes;
+   size_t longest_adapter_size;
 
    // vector to be reported
    std::vector<std::vector<double>> adapter_pos_pct;

--- a/src/StreamReader.hpp
+++ b/src/StreamReader.hpp
@@ -65,6 +65,9 @@ class StreamReader{
   const size_t buffer_size;
 
   /************ ADAPTER SEARCH ***********/
+  const bool adapters_search_slow;
+  const std::vector<std::string> adapter_seqs;
+
   const size_t num_adapters;
   const size_t adapter_size;
   const size_t adapter_mask;

--- a/src/StreamReader.hpp
+++ b/src/StreamReader.hpp
@@ -46,6 +46,7 @@ class StreamReader{
   const bool do_sequence_hash,
              do_kmer,
              do_adapter,
+             do_adapter_optimized,
              do_sliding_window,
              do_n_content,
              do_quality_base,
@@ -65,7 +66,7 @@ class StreamReader{
   const size_t buffer_size;
 
   /************ ADAPTER SEARCH ***********/
-  const bool adapters_search_slow;
+  const bool do_adapters_slow;
   const std::vector<std::string> adapter_seqs;
 
   const size_t num_adapters;


### PR DESCRIPTION
In the case adapters have different length (or adapters have length more then 32) - use slow inefficient search as fastqc does.
I understand - it's inefficient solution, but it works as fastqc. It's better then not processing samples at all.

May be aho-corasick algorithm will be good for this feature, but for now I have no time for it.

Also I fixed current algorithm for adapters with 32 length - adapter mask was calculated as 0. Now it's max size_t for such adapters.