### PR TITLE
show all positions with adapters - got rid of fastqc diff adapters le…

### DIFF
--- a/src/FalcoConfig.cpp
+++ b/src/FalcoConfig.cpp
@@ -546,13 +546,13 @@ FalcoConfig::read_adapters() {
 
       if (adapter_size == 0) {
         adapter_size = adapter_seq.size();
-        longest_adapter_size = adapter_size;
+        shortest_adapter_size = adapter_size;
       }
       else if (adapter_seq.size() != adapter_size) {
         cerr << "[adapters]\tadapters have different size. Use slow adapters search" << "\n";
         do_adapter_optimized = false;
-        if(adapter_seq.size() > longest_adapter_size){
-          longest_adapter_size = adapter_seq.size();
+        if(adapter_seq.size() < shortest_adapter_size){
+          shortest_adapter_size = adapter_seq.size();
         }
       }
 

--- a/src/FalcoConfig.hpp
+++ b/src/FalcoConfig.hpp
@@ -89,7 +89,7 @@ struct FalcoConfig {
   std::vector<size_t> adapter_hashes;
 
   size_t adapter_size;
-  size_t longest_adapter_size;
+  size_t shortest_adapter_size;
   /************************************************************
    ******* ADDITIONAL INFORMATION ABOUT THE SAMPLE ************
    ************************************************************/

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -1842,7 +1842,7 @@ Module(ModuleAdapterContent::module_name) {
   adapter_names = config.adapter_names;
   adapter_seqs = config.adapter_seqs;
   adapter_hashes = config.adapter_hashes;
-  longest_adapter_size = config.longest_adapter_size; 
+  shortest_adapter_size = config.shortest_adapter_size; 
   
   // check if they are all the same size
   if (adapter_names.size() != adapter_seqs.size())
@@ -1870,7 +1870,7 @@ ModuleAdapterContent::summarize_module(FastqStats &stats) {
 
   for (size_t i = 0; i < num_adapters; ++i)
     adapter_pos_pct.push_back(
-        vector<double>(num_bases - longest_adapter_size + 1, 0.0)
+        vector<double>(num_bases - shortest_adapter_size + 1, 0.0)
     );
 
   size_t cnt;

--- a/src/Module.hpp
+++ b/src/Module.hpp
@@ -340,7 +340,7 @@ class ModuleAdapterContent : public Module {
    std::vector<std::string> adapter_names;
    std::vector<std::string> adapter_seqs;
    std::vector<size_t> adapter_hashes;
-   size_t longest_adapter_size;
+   size_t shortest_adapter_size;
 
    // vector to be reported
    std::vector<std::vector<double>> adapter_pos_pct;


### PR DESCRIPTION
Well, when I fixed https://github.com/smithlabcode/falco/issues/23 - I made output like fastqc. 

Last days I analyzed bgi samples with different adapters length. I found out that fastqc (and my previous fix) omits the last positions for short adapters. Now I changed variable longest_adapter_size to shortest_adapter_size to fix this issue.