### PR TITLE
Remove progress bar for BAM input

### DIFF
--- a/src/StreamReader.cpp
+++ b/src/StreamReader.cpp
@@ -1163,7 +1163,14 @@ BamReader::is_eof() {
 
 bool
 BamReader::read_entry(FastqStats &stats, size_t &num_bytes_read) {
+  static const uint16_t not_reverse = ~BAM_FREVERSE;
   if ((rd_ret = sam_read1(hts, hdr, b)) >= 0) {
+
+    if (bam_is_rev(b)) {
+      revcomp_seq_by_byte(b);
+      reverse_quality_scores(b);
+      b->core.flag &= not_reverse;
+    }
 
     num_bytes_read = 0;
     do_read = (stats.num_reads == next_read);

--- a/src/StreamReader.cpp
+++ b/src/StreamReader.cpp
@@ -53,7 +53,6 @@ get_tile_split_position(FalcoConfig &config) {
     size_t tabPos = line.find('\t');
     line = line.substr(0, tabPos);
     for (char c : line) num_colon += (c == ':');
-    std::cout << num_colon << std::endl;
   }
 #ifdef USE_HTS
   else if (config.is_bam) {
@@ -64,7 +63,7 @@ get_tile_split_position(FalcoConfig &config) {
     if (hdr == nullptr)
       throw runtime_error("cannot read header from bam file : " + filename);
     bam1_t *b = bam_init1();
-    if (sam_read1(hts, hdr, b) < - 1) {
+    if (sam_read1(hts, hdr, b) < -1) {
       hts_close(hts);
       sam_hdr_destroy(hdr);
       bam_destroy1(b);

--- a/src/StreamReader.cpp
+++ b/src/StreamReader.cpp
@@ -48,7 +48,7 @@ get_tile_split_position(FalcoConfig &config) {
     if (!sam_file)
       throw runtime_error("cannot load sam file : " + filename);
     string line;
-    while (getline(sam_file, line) && line.size() > 0 && line[0] == '@') 
+    while (getline(sam_file, line) && line.size() > 0 && line[0] == '@')
       continue;
     size_t tabPos = line.find('\t');
     line = line.substr(0, tabPos);
@@ -61,14 +61,14 @@ get_tile_split_position(FalcoConfig &config) {
     if (!hts)
       throw runtime_error("cannot load bam file : " + filename);
     sam_hdr_t *hdr = sam_hdr_read(hts);
-    if (hdr == nullptr) 
+    if (hdr == nullptr)
       throw runtime_error("cannot read header from bam file : " + filename);
     bam1_t *b = bam_init1();
     if (sam_read1(hts, hdr, b) < - 1) {
       hts_close(hts);
       sam_hdr_destroy(hdr);
       bam_destroy1(b);
-    
+
       throw runtime_error("cannot read entry from bam file : " + filename);
     }
     else {
@@ -97,7 +97,7 @@ get_tile_split_position(FalcoConfig &config) {
     }
   } else {
     std::ifstream in(filename);
-    if (!in.good()) 
+    if (!in.good())
       throw std::runtime_error("problem reading input file: " + filename);
 
     // Read the first line of the file
@@ -443,7 +443,7 @@ StreamReader::read_sequence_line(FastqStats &stats) {
     for (size_t i = 0; i != num_adapters; ++i) {
       const size_t adapt_index = seq_line_str.find(adapter_seqs[i], 0);
       if (adapt_index < stats.SHORT_READ_THRESHOLD) {
-        ++stats.pos_adapter_count[((adapt_index + adapter_seqs[i].length() - 1) 
+        ++stats.pos_adapter_count[((adapt_index + adapter_seqs[i].length() - 1)
             << Constants::bit_shift_adapter) | i];
       }
     }
@@ -542,11 +542,11 @@ StreamReader::process_quality_base_from_leftover(FastqStats &stats) {
 void
 StreamReader::read_quality_line(FastqStats &stats) {
   // MN: Below, the second condition tests whether the quality score in sam
-  // file only consists of '*', which indicates that no quality score is 
+  // file only consists of '*', which indicates that no quality score is
   // available
-  if (!do_read || 
-      (*cur_char == '*' && 
-       (*(cur_char + 1) == field_separator || 
+  if (!do_read ||
+      (*cur_char == '*' &&
+       (*(cur_char + 1) == field_separator ||
         *(cur_char + 1) == field_separator) ) ) {
     read_fast_forward_line_eof();
     return;
@@ -937,7 +937,7 @@ BamReader::read_sequence_line(FastqStats &stats) {
     for (size_t i = 0; i != num_adapters; ++i) {
       const size_t adapt_index = seq_line_str.find(adapter_seqs[i], 0);
       if (adapt_index < stats.SHORT_READ_THRESHOLD) {
-        ++stats.pos_adapter_count[((adapt_index + adapter_seqs[i].length() - 1) 
+        ++stats.pos_adapter_count[((adapt_index + adapter_seqs[i].length() - 1)
             << Constants::bit_shift_adapter) | i];
       }
     }
@@ -947,7 +947,7 @@ BamReader::read_sequence_line(FastqStats &stats) {
   /********** THIS LOOP MUST BE ALWAYS OPTIMIZED ***********/
   /*********************************************************/
   // In the following loop, cur_char does not change, but rather i changes
-  // and we access bases using bam_seqi(cur_char, i) in 
+  // and we access bases using bam_seqi(cur_char, i) in
   // put_base_in_buffer.
   for (size_t i = 0; i < seq_len; i++, ++read_pos) {
     // if we reached the buffer size, stop using it and start using leftover
@@ -1017,7 +1017,7 @@ BamReader::read_quality_line(FastqStats &stats) {
     get_base_from_buffer();
 
     // MN: Adding quality_zero to emulate the behavior of the original function.
-    stats.lowest_char = min8(stats.lowest_char, 
+    stats.lowest_char = min8(stats.lowest_char,
         static_cast<char>(*cur_char + 33));
 
     // Converts quality ascii to zero-based
@@ -1094,7 +1094,7 @@ BamReader::read_entry(FastqStats &stats, size_t &num_bytes_read) {
     cur_char = bam_get_qname(b);
     last = cur_char + b->m_data;
     const size_t first_padding_null = b->core.l_qname - b->core.l_extranul - 1;
-    // Turn "QUERYNAME\0\0\0" into "QUERYNAME\t\0\0" (assuming 
+    // Turn "QUERYNAME\0\0\0" into "QUERYNAME\t\0\0" (assuming
     // field_separtor = '\t') to be compatible with read_fast_forward_line().
     cur_char[first_padding_null] = field_separator;
     read_tile_line(stats);
@@ -1108,13 +1108,13 @@ BamReader::read_entry(FastqStats &stats, size_t &num_bytes_read) {
     cur_char = reinterpret_cast<char*>(bam_get_qual(b));
     // Set the first byte after qual to line_separator
     // So that read_quality_line stops at the end of qual
-    cur_char[seq_len] = line_separator; 
+    cur_char[seq_len] = line_separator;
 
     BamReader::read_quality_line(stats);
 
     if (do_read)
       postprocess_fastq_record(stats);
-    
+
     next_read += do_read*read_step;
     ++stats.num_reads;
     return true;
@@ -1149,7 +1149,7 @@ BamReader::read_entry(FastqStats &stats, size_t &num_bytes_read) {
       //StreamReader::read_sequence_line(stats);
       //skip_separator();
       //read_quality_line(stats);
-      
+
       //if (do_read)
         //postprocess_fastq_record(stats);
 

--- a/src/falco.cpp
+++ b/src/falco.cpp
@@ -17,6 +17,7 @@
 
 #include <fstream>
 #include <chrono>
+#include <type_traits>
 
 #include "smithlab_utils.hpp"
 #include "OptionParser.hpp"
@@ -76,11 +77,17 @@ read_stream_into_stats(T &in, FastqStats &stats, FalcoConfig &falco_config) {
   size_t file_size = in.load();
   size_t tot_bytes_read = 0;
 
-  // Read record by record
-  const bool quiet = falco_config.quiet;
+  // can't report progress for bam files
+  constexpr bool is_bam = std::is_same<T, BamReader>::value;
+
+  // decide whether to report progress
+  const bool quiet = falco_config.quiet || is_bam;
+
   ProgressBar progress(file_size, "running falco");
   if (!quiet)
     progress.report(cerr, 0);
+
+  // Read record by record
   while (in.read_entry(stats, tot_bytes_read)) {
     if (!quiet && progress.time_to_report(tot_bytes_read))
       progress.report(cerr, tot_bytes_read);
@@ -195,7 +202,7 @@ write_results(const FalcoConfig &falco_config,
   if (!skip_html) {
     // Decide html filename based on input
     const string html_file =
-      (report_filename.empty() ? 
+      (report_filename.empty() ?
        (outdir + "/" + file_prefix + "fastqc_report.html") :
        (report_filename));
 
@@ -682,7 +689,7 @@ int main(int argc, const char **argv) {
           log_process("reading file as SAM format");
         SamReader in(falco_config, stats.SHORT_READ_THRESHOLD);
         read_stream_into_stats(in, stats, falco_config);
-        stats.adjust_tile_maps_len(); 
+        stats.adjust_tile_maps_len();
       }
 #ifdef USE_HTS
       else if (falco_config.is_bam) {
@@ -698,7 +705,7 @@ int main(int argc, const char **argv) {
         if (!falco_config.quiet)
           log_process("reading file as gzipped FASTQ format");
         GzFastqReader in(falco_config, stats.SHORT_READ_THRESHOLD);
-        read_stream_into_stats(in,stats,falco_config);
+        read_stream_into_stats(in, stats, falco_config);
       }
       else if (falco_config.is_fastq) {
         if (!falco_config.quiet)


### PR DESCRIPTION
The reason to do this is that we do not have the ability to easily monitor progress within a BAM file while reading from it. The solution is just to check the template parameter and force quiet mode if it's a BamReader